### PR TITLE
Debug axios cookie issue

### DIFF
--- a/frontend/src/services/request/index.ts
+++ b/frontend/src/services/request/index.ts
@@ -22,12 +22,11 @@ const ErrorShowTypeMap: { [key: string]: ErrorShowType } = {
 // 从环境变量中读取配置
 // const API_BASE_URL = window.location.hostname === 'localhost' ? "https://manus.proxy.nolaurence.cn" : window.location.origin;
 const API_BASE_URL = window.location.hostname === 'localhost' ? "http://192.168.49.250:7001" : window.location.origin;
-const ALLOW_CORS = window.location.hostname === 'localhost';
 
 // 创建 axios 实例
 const axiosInstance = axios.create({
   baseURL: API_BASE_URL, // 你的 API 基础 URL
-  withCredentials: ALLOW_CORS, // 是否允许跨域携带 cookie
+  withCredentials: true, // 跨域时始终携带 cookie（需配合后端 CORS）
   timeout: 10000, // 请求超时时间
 });
 


### PR DESCRIPTION
Always send cookies with Axios requests by setting `withCredentials: true` unconditionally.

This fixes an issue where cookies were not sent during local debugging from `localhost:8000` to a remote backend, as `withCredentials` was previously gated by `window.location.hostname === 'localhost'`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c95fecd4-6f4b-4a2f-b6ea-b88245e1ec79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c95fecd4-6f4b-4a2f-b6ea-b88245e1ec79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

