### PR TITLE
Integrate agent session and executor with spring

### DIFF
--- a/backend/src/main/java/cn/nolaurene/cms/config/AgentConfig.java
+++ b/backend/src/main/java/cn/nolaurene/cms/config/AgentConfig.java
@@ -1,0 +1,51 @@
+package cn.nolaurene.cms.config;
+
+import cn.nolaurene.cms.service.sandbox.backend.ToolRegistry;
+import cn.nolaurene.cms.service.sandbox.backend.llm.LlmClient;
+import cn.nolaurene.cms.service.sandbox.backend.llm.SiliconFlowClient;
+import cn.nolaurene.cms.service.sandbox.backend.tool.CalculatorTool;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+/**
+ * Agent 相关的 Spring 配置类
+ * 
+ * @author nolau
+ * @date 2025/10/24
+ */
+@Configuration
+public class AgentConfig {
+
+    @Value("${llm-client.silicon-flow.endpoint}")
+    private String siliconFlowEndpoint;
+
+    @Value("${llm-client.silicon-flow.api-key}")
+    private String siliconFlowApiKey;
+
+    // ToolRegistry 已经通过 @Component 注解管理，不需要在这里重复定义
+
+    /**
+     * 创建 LlmClient Bean
+     * 原型模式，每个 Agent 可以有独立的 LLM 客户端配置
+     */
+    @Bean
+    @Scope("prototype")
+    public LlmClient llmClient() {
+        return new SiliconFlowClient(siliconFlowEndpoint, siliconFlowApiKey);
+    }
+
+    /**
+     * 创建带自定义配置的 LlmClient
+     * 
+     * @param endpoint LLM 服务端点
+     * @param apiKey API 密钥
+     * @return LlmClient 实例
+     */
+    @Bean
+    @Scope("prototype")
+    public LlmClient customLlmClient(String endpoint, String apiKey) {
+        return new SiliconFlowClient(endpoint, apiKey);
+    }
+}

--- a/backend/src/main/java/cn/nolaurene/cms/config/ToolRegistryInitializer.java
+++ b/backend/src/main/java/cn/nolaurene/cms/config/ToolRegistryInitializer.java
@@ -1,0 +1,30 @@
+package cn.nolaurene.cms.config;
+
+import cn.nolaurene.cms.service.sandbox.backend.ToolRegistry;
+import cn.nolaurene.cms.service.sandbox.backend.tool.CalculatorTool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * 工具注册表初始化器
+ * 在应用启动时注册默认工具
+ * 
+ * @author nolau
+ * @date 2025/10/24
+ */
+@Component
+public class ToolRegistryInitializer implements CommandLineRunner {
+
+    @Autowired
+    private ToolRegistry toolRegistry;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // 注册默认工具
+        toolRegistry.register(new CalculatorTool());
+        
+        // 可以在这里注册更多工具
+        // toolRegistry.register(new OtherTool());
+    }
+}

--- a/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/AgentController.java
+++ b/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/AgentController.java
@@ -12,6 +12,7 @@ import cn.nolaurene.cms.service.sandbox.backend.message.ConversationHistoryServi
 import cn.nolaurene.cms.common.dto.ConversationRequest;
 import cn.nolaurene.cms.dal.enhance.entity.ConversationHistoryDO;
 import cn.nolaurene.cms.service.sandbox.backend.agent.AgentSession;
+import cn.nolaurene.cms.service.sandbox.backend.agent.AgentSessionFactory;
 import cn.nolaurene.cms.service.sandbox.backend.McpHeartbeatService;
 import cn.nolaurene.cms.service.sandbox.backend.message.ConversationHistoryService;
 import cn.nolaurene.cms.service.sandbox.backend.session.GlobalAgentSessionManager;
@@ -83,6 +84,9 @@ public class AgentController {
     @Resource
     private McpHeartbeatService mcpHeartbeatService;
 
+    @Resource
+    private AgentSessionFactory agentSessionFactory;
+
     private ThreadPoolExecutor executor;
 
     @Resource
@@ -129,8 +133,7 @@ public class AgentController {
 //                return Response.error("Failed to create mcp server", null);
 //            }
 
-            AgentSession agentSession = new AgentSession(agent, workerUrl, sseEndpoint);
-            mcpHeartbeatService.addClient(agent.getMcpClient());
+            AgentSession agentSession = agentSessionFactory.createAgentSession(agent, workerUrl, sseEndpoint);
 
             try {
                 boolean result = globalAgentSessionManager.createSession(agentId, agentSession);

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/ToolRegistry.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/ToolRegistry.java
@@ -2,14 +2,16 @@ package cn.nolaurene.cms.service.sandbox.backend;
 
 
 import cn.nolaurene.cms.service.sandbox.backend.tool.Tool;
+import org.springframework.stereotype.Component;
 
 import java.util.*;
 
 /**
  * @author nolau
  * @date 2025/6/24
- * @description
+ * @description 工具注册表，由 Spring 管理的单例组件
  */
+@Component
 public class ToolRegistry {
 
     private final Map<String, Tool> tools = new HashMap<>();

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutor.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutor.java
@@ -28,6 +28,9 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.BufferedReader;
@@ -45,9 +48,11 @@ import java.util.stream.Collectors;
 /**
  * @author nolau
  * @date 2025/6/24
- * @description
+ * @description Agent 执行器，由 Spring 管理的原型组件
  */
 @Slf4j
+@Component
+@Scope("prototype")
 public class AgentExecutor {
 
     private final int MAX_ROUNDS;
@@ -82,7 +87,23 @@ public class AgentExecutor {
     private String conversationUserId = "anonymous";
     private String conversationSessionId = null; // fallback to agentId if null
 
-    public AgentExecutor(ToolRegistry tools, LlmClient llm, Agent agent) {
+    /**
+     * Spring 构造函数注入
+     * 注意：由于是原型 Bean，每次创建时都会调用此构造函数
+     */
+    public AgentExecutor() {
+        // 空构造函数，由 Spring 管理依赖注入
+        this.MAX_ROUNDS = 30; // 默认值，会在 initialize 方法中覆盖
+    }
+
+    /**
+     * 初始化方法，在 Spring 创建实例后调用
+     * 
+     * @param tools 工具注册表
+     * @param llm LLM 客户端
+     * @param agent Agent 配置
+     */
+    public void initialize(ToolRegistry tools, LlmClient llm, Agent agent) {
         this.tools = tools;
         this.llm = llm;
         this.MAX_ROUNDS = agent.getMaxLoop();

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutorFactory.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutorFactory.java
@@ -1,0 +1,56 @@
+package cn.nolaurene.cms.service.sandbox.backend.agent;
+
+import cn.nolaurene.cms.common.sandbox.backend.model.Agent;
+import cn.nolaurene.cms.service.sandbox.backend.ToolRegistry;
+import cn.nolaurene.cms.service.sandbox.backend.llm.LlmClient;
+import cn.nolaurene.cms.service.sandbox.backend.llm.SiliconFlowClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+/**
+ * AgentExecutor 工厂服务
+ * 负责创建和配置 AgentExecutor 实例
+ * 
+ * @author nolau
+ * @date 2025/10/24
+ */
+@Service
+public class AgentExecutorFactory {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private ToolRegistry toolRegistry;
+
+    /**
+     * 创建 AgentExecutor 实例
+     * 
+     * @param agent Agent 配置信息
+     * @return AgentExecutor 实例
+     */
+    public AgentExecutor createAgentExecutor(Agent agent) {
+        // 创建专用的 LLM 客户端
+        LlmClient llmClient = createLlmClient(agent.getLlmEndpoint(), agent.getLlmApiKey());
+        
+        // 使用 Spring 的 ApplicationContext 创建 AgentExecutor
+        AgentExecutor executor = applicationContext.getBean(AgentExecutor.class);
+        
+        // 初始化 AgentExecutor
+        executor.initialize(toolRegistry, llmClient, agent);
+        
+        return executor;
+    }
+
+    /**
+     * 创建 LLM 客户端
+     * 
+     * @param endpoint LLM 服务端点
+     * @param apiKey API 密钥
+     * @return LlmClient 实例
+     */
+    private LlmClient createLlmClient(String endpoint, String apiKey) {
+        return new SiliconFlowClient(endpoint, apiKey);
+    }
+}

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentSessionFactory.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentSessionFactory.java
@@ -1,0 +1,48 @@
+package cn.nolaurene.cms.service.sandbox.backend.agent;
+
+import cn.nolaurene.cms.common.sandbox.backend.model.Agent;
+import cn.nolaurene.cms.service.sandbox.backend.McpHeartbeatService;
+import cn.nolaurene.cms.service.sandbox.backend.ToolRegistry;
+import cn.nolaurene.cms.service.sandbox.backend.llm.LlmClient;
+import cn.nolaurene.cms.service.sandbox.backend.llm.SiliconFlowClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+/**
+ * AgentSession 工厂服务
+ * 负责创建和配置 AgentSession 实例
+ * 
+ * @author nolau
+ * @date 2025/10/24
+ */
+@Service
+public class AgentSessionFactory {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private AgentExecutorFactory agentExecutorFactory;
+
+    @Autowired
+    private McpHeartbeatService mcpHeartbeatService;
+
+    /**
+     * 创建 AgentSession 实例
+     * 
+     * @param agent Agent 配置信息
+     * @param workerUrl Worker 服务 URL
+     * @param sseEndpoint SSE 端点
+     * @return AgentSession 实例
+     */
+    public AgentSession createAgentSession(Agent agent, String workerUrl, String sseEndpoint) {
+        // 使用 Spring 的 ApplicationContext 创建 AgentSession
+        AgentSession agentSession = applicationContext.getBean(AgentSession.class);
+        
+        // 初始化 AgentSession
+        agentSession.initialize(agent, workerUrl, sseEndpoint, agentExecutorFactory, mcpHeartbeatService);
+        
+        return agentSession;
+    }
+}


### PR DESCRIPTION
Refactor `AgentSession` and `AgentExecutor` to be Spring-managed prototype components, and `ToolRegistry` as a Spring-managed singleton.

This change integrates `AgentSession` and `AgentExecutor` into the Spring framework, enabling dependency injection, improved lifecycle management, and enhanced testability by replacing manual object creation with Spring's IoC container and factory services.

---
<a href="https://cursor.com/background-agent?bcId=bc-3de03352-de27-4137-81c8-9e7cad464172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3de03352-de27-4137-81c8-9e7cad464172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

