### PR TITLE
feat: persist tool execution results into conversation history

### DIFF
--- a/backend/src/main/java/cn/nolaurene/cms/common/sandbox/backend/llm/ChatMemory.java
+++ b/backend/src/main/java/cn/nolaurene/cms/common/sandbox/backend/llm/ChatMemory.java
@@ -43,7 +43,8 @@ public class ChatMemory {
                 .filter(msg -> msg.getRole() != ChatMessage.Role.tool)
                 .filter(msg -> msg.getEventType() == SSEEventType.MESSAGE
                         || msg.getEventType() == SSEEventType.PLAN
-                        || msg.getEventType() == SSEEventType.STEP)
+                        || msg.getEventType() == SSEEventType.STEP
+                        || msg.getEventType() == SSEEventType.TOOL)
                 .map(ChatMessage::toLangchain4j)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/cn/nolaurene/cms/common/sandbox/backend/llm/ChatMessage.java
+++ b/backend/src/main/java/cn/nolaurene/cms/common/sandbox/backend/llm/ChatMessage.java
@@ -51,6 +51,16 @@ public class ChatMessage {
             case user:
                 return UserMessage.from(content != null ? content : "");
             case assistant:
+                if (eventType == SSEEventType.TOOL) {
+                    cn.nolaurene.cms.common.sandbox.backend.model.data.ToolEventData toolData =
+                            com.alibaba.fastjson.JSON.parseObject(content, cn.nolaurene.cms.common.sandbox.backend.model.data.ToolEventData.class);
+                    String result = toolData.getResult();
+                    if (result == null || result.isEmpty()) {
+                        result = "(no result)";
+                    }
+                    String toolDesc = "[Tool] " + toolData.getFunction() + "\nResult: " + result;
+                    return UserMessage.from(toolDesc);
+                }
                 AiMessage.Builder builder = AiMessage.builder()
                         .text(content != null ? content : "");
                 if (thinking != null && !thinking.isEmpty()) {

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutor.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutor.java
@@ -431,6 +431,11 @@ public class AgentExecutor {
                     response = chatModel.chat(request);
                 }
                 AiMessage aiMessage = response.aiMessage();
+                log.info("[LLM Response] round={} text={} thinking={} toolCalls={}",
+                        round,
+                        StringUtils.abbreviate(aiMessage.text(), 200),
+                        StringUtils.abbreviate(aiMessage.thinking(), 200),
+                        aiMessage.hasToolExecutionRequests() ? aiMessage.toolExecutionRequests().size() : 0);
                 messages.add(aiMessage);
                 syncRespondThinking(aiMessage, emitter);
 

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutor.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentExecutor.java
@@ -563,11 +563,14 @@ public class AgentExecutor {
             finalArguments = finalToolRequest.arguments();
         }
 
-        reportToolEvent(toolName, finalArguments, emitter);
+        Long toolMessageId = reportToolEvent(toolName, finalArguments, emitter);
         String observation = skillToolProvider.isSkillTool(toolName)
                 ? executeSkillTool(toolName, finalToolRequest)
                 : executeMcpToolWithRetry(toolName, finalToolRequest);
         log.info("[SKILL LOOP] tool {} result: {}", toolName, observation);
+        if (toolMessageId != null) {
+            conversationHistoryService.updateToolResult(toolMessageId, observation);
+        }
         return ToolExecutionResultMessage.from(toolRequest, observation);
     }
 
@@ -825,7 +828,7 @@ public class AgentExecutor {
         }
     }
 
-    private void reportToolEvent(String toolName, String arguments, SseEmitter emitter) {
+    private Long reportToolEvent(String toolName, String arguments, SseEmitter emitter) {
         ToolEventData toolEventData = new ToolEventData();
         toolEventData.setTimestamp(System.currentTimeMillis());
         toolEventData.setName(resolveToolType(toolName));
@@ -843,6 +846,7 @@ public class AgentExecutor {
         if (toolMessageId != null) {
             currentStepToolIds.add(toolMessageId);
         }
+        return toolMessageId;
     }
 
     private String resolveToolType(String toolName) {

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/ExecutionSubAgent.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/ExecutionSubAgent.java
@@ -216,11 +216,14 @@ public class ExecutionSubAgent {
                     }
 
                     // Report tool event to frontend via SSE
-                    reportToolEvent(toolName, finalArguments, agent, emitterOpt);
+                    Long toolMessageId = reportToolEvent(toolName, finalArguments, agent, emitterOpt);
 
                     // Execute tool via MCP Client directly
                     String observation = executeToolWithRetry(toolName, finalToolRequest, agent);
                     log.info("[ExecutionSubAgent] Round {} - Tool {} result: {}", round, toolName, observation);
+                    if (toolMessageId != null) {
+                        conversationHistoryService.updateToolResult(toolMessageId, observation);
+                    }
 
                     // Add tool result to messages
                     messages.add(ToolExecutionResultMessage.from(toolRequest, observation));
@@ -420,10 +423,13 @@ public class ExecutionSubAgent {
                         finalArguments = finalToolRequest.arguments();
                     }
 
-                    reportToolEvent(toolName, finalArguments, agent, emitterOpt);
+                    Long toolMessageId = reportToolEvent(toolName, finalArguments, agent, emitterOpt);
 
                     String observation = executeToolWithRetry(toolName, finalToolRequest, agent);
                     log.info("[ExecutionSubAgent] Skill Round {} - Tool {} result: {}", round, toolName, observation);
+                    if (toolMessageId != null) {
+                        conversationHistoryService.updateToolResult(toolMessageId, observation);
+                    }
 
                     messages.add(ToolExecutionResultMessage.from(toolRequest, observation));
                 }
@@ -492,10 +498,13 @@ public class ExecutionSubAgent {
 
                 JSONObject skillArgs = new JSONObject();
                 skillArgs.put("command", command);
-                reportToolEvent("shell_skill_execute", skillArgs.toJSONString(), agent, emitterOpt);
+                Long toolMessageId = reportToolEvent("shell_skill_execute", skillArgs.toJSONString(), agent, emitterOpt);
 
                 String observation = executeSkillCommand(selectedSkillId, sessionId, command, agent);
                 log.info("[ExecutionSubAgent] Skill command result: {}", observation);
+                if (toolMessageId != null) {
+                    conversationHistoryService.updateToolResult(toolMessageId, observation);
+                }
 
                 messages.add(UserMessage.from("Command output:\n" + observation));
 
@@ -1317,8 +1326,9 @@ public class ExecutionSubAgent {
 
     /**
      * Report tool execution event to SSE and persistence.
+     * Returns the persisted message ID so the caller can update with the result later.
      */
-    private void reportToolEvent(String toolName, String arguments, Agent agent, SseEmitter emitter) {
+    private Long reportToolEvent(String toolName, String arguments, Agent agent, SseEmitter emitter) {
         String toolType;
         if (toolName.startsWith("browser")) {
             toolType = "browser";
@@ -1350,7 +1360,7 @@ public class ExecutionSubAgent {
         }
 
         // Persist
-        conversationHistoryService.saveAssistantMessageWithId(
+        return conversationHistoryService.saveAssistantMessageWithId(
                 JSON.toJSONString(toolEventData), SSEEventType.TOOL,
                 agent.getUserId(), agent.getAgentId());
     }

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/ExecutionSubAgent.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/ExecutionSubAgent.java
@@ -182,6 +182,11 @@ public class ExecutionSubAgent {
                 response = chatModel.chat(request);
             }
             AiMessage aiMessage = response.aiMessage();
+            log.info("[LLM Response] round={} text={} thinking={} toolCalls={}",
+                    round,
+                    StringUtils.abbreviate(aiMessage.text(), 200),
+                    StringUtils.abbreviate(aiMessage.thinking(), 200),
+                    aiMessage.hasToolExecutionRequests() ? aiMessage.toolExecutionRequests().size() : 0);
             sendThinkingMessageEvent(aiMessage, agent, emitterOpt);
 
             // Add AI message to conversation
@@ -381,6 +386,11 @@ public class ExecutionSubAgent {
                 response = chatModel.chat(request);
             }
             AiMessage aiMessage = response.aiMessage();
+            log.info("[LLM Response] round={} text={} thinking={} toolCalls={}",
+                    round,
+                    StringUtils.abbreviate(aiMessage.text(), 200),
+                    StringUtils.abbreviate(aiMessage.thinking(), 200),
+                    aiMessage.hasToolExecutionRequests() ? aiMessage.toolExecutionRequests().size() : 0);
             sendThinkingMessageEvent(aiMessage, agent, emitterOpt);
             String aiText = aiMessage.text();
             log.info("[ExecutionSubAgent] Skill Round {} - LLM response: {}", round, aiText);
@@ -704,7 +714,9 @@ public class ExecutionSubAgent {
 
         try {
             ChatResponse response = chatModel.chat(request);
-            String selectedSkillId = response.aiMessage().text().trim();
+            AiMessage aiMessage = response.aiMessage();
+            log.info("[LLM Response] selectSkill text={}", StringUtils.abbreviate(aiMessage.text(), 200));
+            String selectedSkillId = aiMessage.text().trim();
 
             // Clean up response
             if (selectedSkillId.startsWith("```") && selectedSkillId.endsWith("```")) {
@@ -951,6 +963,9 @@ public class ExecutionSubAgent {
         try {
             ChatResponse checkResponse = chatModel.chat(checkRequest);
             AiMessage checkAiMessage = checkResponse.aiMessage();
+            log.info("[LLM Response] checkStepCompletion text={} toolCalls={}",
+                    StringUtils.abbreviate(checkAiMessage.text(), 200),
+                    checkAiMessage.hasToolExecutionRequests() ? checkAiMessage.toolExecutionRequests().size() : 0);
             String responseText = checkAiMessage.text();
 
             if (responseText != null && responseText.startsWith("COMPLETED:")) {
@@ -980,6 +995,7 @@ public class ExecutionSubAgent {
                         .messages(compactedMessages)
                         .build());
                 AiMessage checkAiMessage = checkResponse.aiMessage();
+                log.info("[LLM Response] checkStepCompletion retry text={}", StringUtils.abbreviate(checkAiMessage.text(), 200));
                 String responseText = checkAiMessage.text();
                 if (responseText != null && responseText.startsWith("COMPLETED:")) {
                     messages.clear();
@@ -1063,6 +1079,9 @@ public class ExecutionSubAgent {
             long thinkTime = System.currentTimeMillis() - startTime;
 
             AiMessage aiMessage = response.aiMessage();
+            log.info("[LLM Response] deepThinking text={} thinking={}",
+                    StringUtils.abbreviate(aiMessage.text(), 200),
+                    StringUtils.abbreviate(aiMessage.thinking(), 200));
             String thinkingContent = aiMessage.text();
 
             if (StringUtils.isNotBlank(thinkingContent)) {

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/message/ConversationHistoryService.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/message/ConversationHistoryService.java
@@ -65,6 +65,34 @@ public class ConversationHistoryService {
     }
 
     /**
+     * Update tool result in conversation history after execution completes.
+     * Parses the existing JSON content, adds the result field, and updates the record.
+     */
+    public void updateToolResult(Long messageId, String result) {
+        if (messageId == null || result == null) {
+            return;
+        }
+        try {
+            ConversationHistoryDO existing = conversationHistoryTkMapper.selectByPrimaryKey(messageId);
+            if (existing == null) {
+                log.warn("updateToolResult: message not found, id={}", messageId);
+                return;
+            }
+            String content = existing.getContent();
+            if (StringUtils.isBlank(content)) {
+                return;
+            }
+            JSONObject json = JSON.parseObject(content);
+            json.put("result", result);
+            existing.setContent(json.toJSONString());
+            conversationHistoryTkMapper.updateByPrimaryKeySelective(existing);
+            log.info("updateToolResult: updated tool result for message id={}", messageId);
+        } catch (Exception e) {
+            log.warn("failed to update tool result, messageId={}", messageId, e);
+        }
+    }
+
+    /**
      * 保存对话历史
      */
     @Transactional


### PR DESCRIPTION
- ConversationHistoryService: add updateToolResult() to patch result into existing tool event JSON
- AgentExecutor: reportToolEvent now returns toolMessageId; executeAgentLoopTool updates DB after tool execution
- ExecutionSubAgent: reportToolEvent now returns toolMessageId; all 3 tool call sites (directTools, skill MCP, skill shell) update DB with observation