### PR TITLE
feat(sandbox): add sandbox lease management and per-agent acquire/release

### DIFF
--- a/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/AgentController.java
+++ b/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/AgentController.java
@@ -22,6 +22,8 @@ import cn.nolaurene.cms.service.sandbox.backend.agent.AgentSession;
 import cn.nolaurene.cms.service.sandbox.backend.McpHeartbeatService;
 import cn.nolaurene.cms.service.sandbox.backend.SseMessageForwardService;
 import cn.nolaurene.cms.service.sandbox.backend.session.GlobalAgentSessionManager;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxLease;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxPoolService;
 import com.alibaba.fastjson2.JSON;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.mcp.client.McpClient;
@@ -121,6 +123,9 @@ public class AgentController {
     @Resource
     private SseMessageForwardService sseMessageForwardService;
 
+    @Resource
+    private SandboxPoolService sandboxPoolService;
+
     @PostConstruct
     public void initThreadPool() {
         executor = new ThreadPoolExecutor(
@@ -162,6 +167,7 @@ public class AgentController {
         }
 
         // 重试三次
+        Exception lastCreateException = null;
         for (int i = 0; i < MAX_RETRIES; i++) {
             Agent agent = new Agent();
             agent.setUserId(null != currentUserInfo ? currentUserInfo.getUserid().toString() : "anonymous");
@@ -174,9 +180,10 @@ public class AgentController {
             agent.setLlmApiKey(apiKey);
             agent.setLlmModelName(modelName);
 
-            AgentSession agentSession = agentSessionFactory.createAgentSession(agent, workerUrl, sseEndpoint);
-
+            SandboxLease sandboxLease = null;
             try {
+                sandboxLease = sandboxPoolService.acquire(agentId);
+                AgentSession agentSession = agentSessionFactory.createAgentSession(agent, sandboxLease, sseEndpoint);
                 boolean result = globalAgentSessionManager.createSession(agentId, agentSession);
                 if (result) {
                     String currentIp = agentSessionServerService.getCurrentServerIp();
@@ -188,12 +195,29 @@ public class AgentController {
                     agentInfo.setMessage(agent.getMessage());
                     return Response.success(agentInfo);
                 }
+                agentSession.releaseResources();
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                lastCreateException = e;
+                if (sandboxLease != null) {
+                    sandboxPoolService.release(agentId);
+                }
+                log.error("创建Agent失败: agentId={}, attempt={}/{}", agentId, i + 1, MAX_RETRIES, e);
             }
         }
 
-        return Response.error("Failed to create agent after 3 attempts.", null);
+        String errorMessage = lastCreateException == null ? "Failed to create agent after 3 attempts." : lastCreateException.getMessage();
+        return Response.error(errorMessage, null);
+    }
+
+    @DeleteMapping("/{agentId}")
+    public Response<Boolean> releaseAgent(@PathVariable String agentId, HttpServletRequest httpServletRequest) {
+        User currentUserInfo = userLoginService.getCurrentUserInfo(httpServletRequest);
+        if (null == currentUserInfo) {
+            return Response.error("未登录", false);
+        }
+        globalAgentSessionManager.removeSession(agentId);
+        agentSessionServerService.deleteByAgentId(agentId);
+        return Response.success(true);
     }
 
     @PostMapping("/{agentId}/chat")

--- a/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/BackendShellWebSocketHandler.java
+++ b/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/BackendShellWebSocketHandler.java
@@ -1,6 +1,6 @@
 package cn.nolaurene.cms.controller.sandbox.backend;
 
-import org.springframework.beans.factory.annotation.Value;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxUrlResolver;
 import org.springframework.stereotype.Component;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.socket.*;
@@ -13,10 +13,13 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class BackendShellWebSocketHandler implements WebSocketHandler {
 
-    @Value("${sandbox.backend.worker-ops-url}")
-    private String workerOpsUrl;
+    private final SandboxUrlResolver sandboxUrlResolver;
 
     private final ConcurrentHashMap<String, WebSocketSession> workerSessions = new ConcurrentHashMap<>();
+
+    public BackendShellWebSocketHandler(SandboxUrlResolver sandboxUrlResolver) {
+        this.sandboxUrlResolver = sandboxUrlResolver;
+    }
 
 
     @Override
@@ -66,6 +69,7 @@ public class BackendShellWebSocketHandler implements WebSocketHandler {
 
         return workerSessions.computeIfAbsent(sessionKey, key -> {
             try {
+                String workerOpsUrl = sandboxUrlResolver.workerOpsUrl(workerId);
                 String workerWsUrl = "ws://" + workerOpsUrl.replace("http://", "").replace("https://", "") + "/worker/shell/wss";
                 WebSocketClient client = new StandardWebSocketClient();
                 ListenableFuture<WebSocketSession> future = client.doHandshake(

--- a/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/BrowserStreamProxyController.java
+++ b/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/BrowserStreamProxyController.java
@@ -2,12 +2,12 @@ package cn.nolaurene.cms.controller.sandbox.backend;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxUrlResolver;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,8 +29,11 @@ public class BrowserStreamProxyController {
 
     private final HttpClient httpClient = HttpClientBuilder.create().build();
 
-    @Value("${sandbox.backend.worker-stream-url}")
-    private String workerHost;
+    private final SandboxUrlResolver sandboxUrlResolver;
+
+    public BrowserStreamProxyController(SandboxUrlResolver sandboxUrlResolver) {
+        this.sandboxUrlResolver = sandboxUrlResolver;
+    }
 
     // HLS M3U8 文件的 MIME 类型
     private static final String APPLICATION_X_MPEGURL = "application/vnd.apple.mpegurl";
@@ -40,7 +43,7 @@ public class BrowserStreamProxyController {
     @GetMapping("/{streamId}.m3u8")
     public ResponseEntity<StreamingResponseBody> proxyHlsMaster(@PathVariable String streamId) {
 
-        String url = workerHost + "/worker/stream/" + streamId + ".m3u8";
+        String url = sandboxUrlResolver.workerStreamUrl(streamId) + "/worker/stream/" + streamId + ".m3u8";
         HttpGet httpGet = new HttpGet(url);
 
         String resultCode = "";
@@ -83,7 +86,7 @@ public class BrowserStreamProxyController {
     public ResponseEntity<StreamingResponseBody> proxyHlsSegment(
             @PathVariable String streamId,
             @PathVariable String index) {
-        String url = workerHost + "/worker/stream/" + streamId + "_" + index + ".ts";
+        String url = sandboxUrlResolver.workerStreamUrl(streamId) + "/worker/stream/" + streamId + "_" + index + ".ts";
 
         HttpGet httpGet = new HttpGet(url);
         String resultCode = "";
@@ -124,7 +127,7 @@ public class BrowserStreamProxyController {
     @Operation(summary = "代理启动流媒体")
     @GetMapping("/start/{streamId}")
     public ResponseEntity<StreamingResponseBody> proxyStartStream(@PathVariable String streamId) {
-        String url = workerHost + "/worker/stream/start/" + streamId;
+        String url = sandboxUrlResolver.workerStreamUrl(streamId) + "/worker/stream/start/" + streamId;
         HttpGet httpGet = new HttpGet(url);
 
         String resultCode = "";
@@ -165,7 +168,7 @@ public class BrowserStreamProxyController {
     @Operation(summary = "代理停止流媒体")
     @GetMapping("/stop/{streamId}")
     public ResponseEntity<StreamingResponseBody> proxyStopStream(@PathVariable String streamId) {
-        String url = workerHost + "/worker/stream/stop/" + streamId;
+        String url = sandboxUrlResolver.workerStreamUrl(streamId) + "/worker/stream/stop/" + streamId;
 
         HttpGet httpGet = new HttpGet(url);
         String resultCode = "";

--- a/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/ShellManageController.java
+++ b/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/ShellManageController.java
@@ -1,6 +1,6 @@
 package cn.nolaurene.cms.controller.sandbox.backend;
 
-import org.springframework.beans.factory.annotation.Value;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxUrlResolver;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
@@ -11,17 +11,19 @@ import java.util.Map;
 @RequestMapping("/proxy/shell")
 public class ShellManageController {
 
-    @Value("${sandbox.backend.worker-ops-url}")
-    private String workerOpsUrl;
-
+    private final SandboxUrlResolver sandboxUrlResolver;
     private final RestTemplate restTemplate = new RestTemplate();
+
+    public ShellManageController(SandboxUrlResolver sandboxUrlResolver) {
+        this.sandboxUrlResolver = sandboxUrlResolver;
+    }
 
     // 2. Shell 执行
     @PostMapping("/shell/exec")
     public ResponseEntity<?> exec(@RequestParam String containerId, @RequestBody Map<String, String> command) {
 //        String ip = workerManager.getWorkerIp(containerId);
 //        String url = "http://" + ip + ":8080/worker/shell/exec";
-        String url = workerOpsUrl + "/worker/shell/exec";
+        String url = sandboxUrlResolver.workerOpsUrl(containerId) + "/worker/shell/exec";
         return restTemplate.postForEntity(url, command, Object.class);
     }
 }

--- a/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/VncProxyController.java
+++ b/backend/src/main/java/cn/nolaurene/cms/controller/sandbox/backend/VncProxyController.java
@@ -1,11 +1,12 @@
 package cn.nolaurene.cms.controller.sandbox.backend;
 
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxUrlResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,14 +23,17 @@ import java.util.Map;
 @Tag(name = "VNC Proxy", description = "VNC 代理服务")
 public class VncProxyController {
 
-    @Value("${sandbox.backend.worker-vnc-url}")
-    private String workerVncUrl;
+    private final SandboxUrlResolver sandboxUrlResolver;
+
+    public VncProxyController(SandboxUrlResolver sandboxUrlResolver) {
+        this.sandboxUrlResolver = sandboxUrlResolver;
+    }
 
     @Operation(summary = "获取 VNC 配置信息")
     @GetMapping("/config")
-    public ResponseEntity<Map<String, Object>> getVncConfig() {
+    public ResponseEntity<Map<String, Object>> getVncConfig(@RequestParam(value = "agentId", required = false) String agentId) {
         Map<String, Object> config = new HashMap<>();
-        config.put("workerVncUrl", workerVncUrl);
+        config.put("workerVncUrl", sandboxUrlResolver.workerVncUrl(agentId));
         config.put("proxyEndpoint", "/vnc");
         config.put("status", "available");
         return ResponseEntity.ok(config);

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/McpHeartbeatService.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/McpHeartbeatService.java
@@ -6,14 +6,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 @Slf4j
 public class McpHeartbeatService {
 
-    private final List<McpClient> mcpClients = new ArrayList<>();
+    private final List<McpClient> mcpClients = new CopyOnWriteArrayList<>();
 
     public void addClient(McpClient client) {
         if (client != null) {
@@ -21,6 +21,12 @@ public class McpHeartbeatService {
             log.info("Adding client to mcp heartbeat service");
         } else {
             log.warn("Attempted to add a null McpClient");
+        }
+    }
+
+    public void removeClient(McpClient client) {
+        if (client != null && mcpClients.remove(client)) {
+            log.info("Removed client from mcp heartbeat service");
         }
     }
 

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentSession.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentSession.java
@@ -6,6 +6,8 @@ import cn.nolaurene.cms.service.sandbox.backend.ToolRegistry;
 import cn.nolaurene.cms.service.sandbox.backend.message.TaskStatus;
 import cn.nolaurene.cms.service.sandbox.backend.message.ConversationHistoryService;
 import cn.nolaurene.cms.service.sandbox.backend.skill.SkillToolProvider;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxLease;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxPoolService;
 import cn.nolaurene.cms.service.sandbox.backend.tool.CalculatorTool;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
@@ -18,7 +20,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -46,11 +47,16 @@ public class AgentSession {
     @Setter
     private TaskStatus sessionStatus = TaskStatus.PENDING;
 
-    @Value("${sandbox.backend.worker-mcp-url}")
-    private String workerNativeMcpUrl;
-
     @Autowired
     private SkillToolProvider skillToolProvider;
+
+    @Autowired
+    private SandboxPoolService sandboxPoolService;
+
+    @Getter
+    private SandboxLease sandboxLease;
+
+    private McpHeartbeatService mcpHeartbeatService;
 
     private AgentExecutor executor;
 
@@ -62,61 +68,68 @@ public class AgentSession {
     public AgentSession() {
     }
 
-    public void initialize(Agent agent, String workerUrl, String sseEndpoint,
+    public void initialize(Agent agent, SandboxLease sandboxLease, String sseEndpoint,
                            AgentExecutorFactory agentExecutorFactory,
                            McpHeartbeatService mcpHeartbeatService) {
         this.agent = agent;
+        this.sandboxLease = sandboxLease;
+        this.mcpHeartbeatService = mcpHeartbeatService;
         this.agent.setPlanner(new Planner());
         this.agent.setExecutor(new Executor());
 
-        // start langchain4j MCP clients
-        McpClient browserMcpClient = startLangchain4jMcpClient(workerUrl, sseEndpoint, "BrowserMCP");
-        agent.setBrowserMcpClient(browserMcpClient);
+        try {
+            // start langchain4j MCP clients
+            McpClient browserMcpClient = startLangchain4jMcpClient(sandboxLease.getWorkerUrl(), sseEndpoint, "BrowserMCP");
+            agent.setBrowserMcpClient(browserMcpClient);
 
-        // add to heartbeat service
-        if (mcpHeartbeatService != null) {
-            mcpHeartbeatService.addClient(browserMcpClient);
+            // add to heartbeat service
+            if (mcpHeartbeatService != null) {
+                mcpHeartbeatService.addClient(browserMcpClient);
+            }
+
+            // verify browser tools available
+            List<ToolSpecification> browserTools = browserMcpClient.listTools();
+            if (browserTools == null || browserTools.isEmpty()) {
+                log.error("No tools found in Browser MCP server at {}", sandboxLease.getWorkerUrl());
+                throw new IllegalStateException("No tools found in Browser MCP server");
+            }
+            log.info("Browser MCP tools discovered: {}", browserTools.size());
+
+            // start native mcp client (for file and shell tool)
+            McpClient nativeMcpClient = startLangchain4jMcpClient(sandboxLease.getWorkerMcpUrl(), "/mcp/message/sse", "NativeMCP");
+            agent.setNativeMcpClient(nativeMcpClient);
+
+            List<ToolSpecification> nativeTools = nativeMcpClient.listTools();
+            if (nativeTools == null || nativeTools.isEmpty()) {
+                log.error("No tools found in Native MCP server at {}", sandboxLease.getWorkerMcpUrl());
+                throw new IllegalStateException("No tools found in Native MCP server");
+            }
+            log.info("Native MCP tools discovered: {}", nativeTools.size());
+
+            // create McpToolProvider that aggregates both MCP clients
+            McpToolProvider toolProvider = McpToolProvider.builder()
+                    .mcpClients(browserMcpClient, nativeMcpClient)
+                    .build();
+            agent.setToolProvider(toolProvider);
+
+            // collect all tool specifications
+            List<ToolSpecification> allTools = new ArrayList<>(browserTools);
+            allTools.addAll(nativeTools);
+            // Load Skill tools for the current user and add to tool specifications
+            List<ToolSpecification> skillTools = skillToolProvider.getSkillToolSpecificationsForUser(parseUserId(agent.getUserId()));
+            allTools.addAll(skillTools);
+            log.info("Skill tools discovered: {}", skillTools.size());
+
+            agent.setToolSpecifications(allTools);
+            log.info("Total tools available (MCP + Skills): {}", allTools.size());
+
+            ToolRegistry registry = new ToolRegistry();
+            registry.register(new CalculatorTool());
+            this.executor = agentExecutorFactory.createAgentExecutor(agent);
+        } catch (RuntimeException e) {
+            releaseResources();
+            throw e;
         }
-
-        // verify browser tools available
-        List<ToolSpecification> browserTools = browserMcpClient.listTools();
-        if (browserTools == null || browserTools.isEmpty()) {
-            log.error("No tools found in Browser MCP server at {}", workerUrl);
-            throw new IllegalStateException("No tools found in Browser MCP server");
-        }
-        log.info("Browser MCP tools discovered: {}", browserTools.size());
-
-        // start native mcp client (for file and shell tool)
-        McpClient nativeMcpClient = startLangchain4jMcpClient(workerNativeMcpUrl, "/mcp/message/sse", "NativeMCP");
-        agent.setNativeMcpClient(nativeMcpClient);
-
-        List<ToolSpecification> nativeTools = nativeMcpClient.listTools();
-        if (nativeTools == null || nativeTools.isEmpty()) {
-            log.error("No tools found in Native MCP server at {}", workerNativeMcpUrl);
-            throw new IllegalStateException("No tools found in Native MCP server");
-        }
-        log.info("Native MCP tools discovered: {}", nativeTools.size());
-
-        // create McpToolProvider that aggregates both MCP clients
-        McpToolProvider toolProvider = McpToolProvider.builder()
-                .mcpClients(browserMcpClient, nativeMcpClient)
-                .build();
-        agent.setToolProvider(toolProvider);
-
-        // collect all tool specifications
-        List<ToolSpecification> allTools = new ArrayList<>(browserTools);
-        allTools.addAll(nativeTools);
-        // Load Skill tools for the current user and add to tool specifications
-        List<ToolSpecification> skillTools = skillToolProvider.getSkillToolSpecificationsForUser(parseUserId(agent.getUserId()));
-        allTools.addAll(skillTools);
-        log.info("Skill tools discovered: {}", skillTools.size());
-
-        agent.setToolSpecifications(allTools);
-        log.info("Total tools available (MCP + Skills): {}", allTools.size());
-
-        ToolRegistry registry = new ToolRegistry();
-        registry.register(new CalculatorTool());
-        this.executor = agentExecutorFactory.createAgentExecutor(agent);
     }
 
     private Long parseUserId(String userId) {
@@ -128,6 +141,30 @@ public class AgentSession {
         } catch (NumberFormatException e) {
             log.warn("Invalid userId for skill loading: {}", userId);
             return null;
+        }
+    }
+
+    public void releaseResources() {
+        if (agent != null) {
+            closeMcpClient(agent.getBrowserMcpClient(), "BrowserMCP");
+            closeMcpClient(agent.getNativeMcpClient(), "NativeMCP");
+            sandboxPoolService.release(agent.getAgentId());
+        }
+    }
+
+    private void closeMcpClient(McpClient client, String clientName) {
+        if (client == null) {
+            return;
+        }
+        if (mcpHeartbeatService != null) {
+            mcpHeartbeatService.removeClient(client);
+        }
+        if (client instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) client).close();
+            } catch (Exception e) {
+                log.warn("Failed to close {} client", clientName, e);
+            }
         }
     }
 

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentSessionFactory.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/agent/AgentSessionFactory.java
@@ -3,6 +3,7 @@ package cn.nolaurene.cms.service.sandbox.backend.agent;
 
 import cn.nolaurene.cms.common.sandbox.backend.model.Agent;
 import cn.nolaurene.cms.service.sandbox.backend.McpHeartbeatService;
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxLease;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
@@ -24,12 +25,12 @@ public class AgentSessionFactory {
     @Autowired
     private McpHeartbeatService mcpHeartbeatService;
 
-    public AgentSession createAgentSession(Agent agent, String workerUrl, String sseEndpoint) {
+    public AgentSession createAgentSession(Agent agent, SandboxLease sandboxLease, String sseEndpoint) {
         // 使用 Spring 的 ApplicationContext 创建 AgentSession
         AgentSession agentSession = applicationContext.getBean(AgentSession.class);
 
         // 初始化 AgentSession
-        agentSession.initialize(agent, workerUrl, sseEndpoint, agentExecutorFactory, mcpHeartbeatService);
+        agentSession.initialize(agent, sandboxLease, sseEndpoint, agentExecutorFactory, mcpHeartbeatService);
 
         return agentSession;
     }

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxLease.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxLease.java
@@ -1,0 +1,19 @@
+package cn.nolaurene.cms.service.sandbox.backend.sandbox;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class SandboxLease {
+    private String sandboxId;
+    private String agentId;
+    private String workerUrl;
+    private String workerMcpUrl;
+    private String workerStreamUrl;
+    private String workerOpsUrl;
+    private String workerVncUrl;
+    private Instant leasedAt;
+}

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxPoolService.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxPoolService.java
@@ -1,0 +1,135 @@
+package cn.nolaurene.cms.service.sandbox.backend.sandbox;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+public class SandboxPoolService {
+
+    private final SandboxProperties properties;
+    private final Map<String, SandboxRuntime> sandboxes = new LinkedHashMap<>();
+    private final Map<String, SandboxLease> leasesByAgentId = new ConcurrentHashMap<>();
+
+    public SandboxPoolService(SandboxProperties properties) {
+        this.properties = properties;
+        reloadSandboxes();
+    }
+
+    public synchronized SandboxLease acquire(String agentId) {
+        if (StringUtils.isBlank(agentId)) {
+            throw new IllegalArgumentException("Agent ID不能为空");
+        }
+        SandboxLease existingLease = leasesByAgentId.get(agentId);
+        if (existingLease != null) {
+            return existingLease;
+        }
+        ensureSandboxesLoaded();
+        for (SandboxRuntime sandbox : sandboxes.values()) {
+            if (sandbox.agentIds.size() < sandbox.maxSessions) {
+                sandbox.agentIds.add(agentId);
+                SandboxLease lease = SandboxLease.builder()
+                        .sandboxId(sandbox.id)
+                        .agentId(agentId)
+                        .workerUrl(sandbox.workerUrl)
+                        .workerMcpUrl(sandbox.workerMcpUrl)
+                        .workerStreamUrl(sandbox.workerStreamUrl)
+                        .workerOpsUrl(sandbox.workerOpsUrl)
+                        .workerVncUrl(sandbox.workerVncUrl)
+                        .leasedAt(Instant.now())
+                        .build();
+                leasesByAgentId.put(agentId, lease);
+                log.info("申请沙箱成功: agentId={}, sandboxId={}, currentLeases={}/{}",
+                        agentId, sandbox.id, sandbox.agentIds.size(), sandbox.maxSessions);
+                return lease;
+            }
+        }
+        log.warn("申请沙箱失败: agentId={}, totalSandboxes={}, activeLeases={}",
+                agentId, sandboxes.size(), leasesByAgentId.size());
+        throw new IllegalStateException("暂无可用沙箱，请稍后重试");
+    }
+
+    public synchronized void release(String agentId) {
+        if (StringUtils.isBlank(agentId)) {
+            return;
+        }
+        SandboxLease lease = leasesByAgentId.remove(agentId);
+        if (lease == null) {
+            return;
+        }
+        SandboxRuntime sandbox = sandboxes.get(lease.getSandboxId());
+        if (sandbox != null) {
+            sandbox.agentIds.remove(agentId);
+            log.info("释放沙箱成功: agentId={}, sandboxId={}, currentLeases={}/{}",
+                    agentId, sandbox.id, sandbox.agentIds.size(), sandbox.maxSessions);
+        } else {
+            log.info("释放沙箱成功: agentId={}, sandboxId={} (sandbox config not found)", agentId, lease.getSandboxId());
+        }
+    }
+
+    public SandboxLease getLease(String agentId) {
+        if (StringUtils.isBlank(agentId)) {
+            return null;
+        }
+        return leasesByAgentId.get(agentId);
+    }
+
+    private void ensureSandboxesLoaded() {
+        if (sandboxes.isEmpty()) {
+            reloadSandboxes();
+        }
+    }
+
+    private void reloadSandboxes() {
+        sandboxes.clear();
+        List<SandboxProperties.Instance> configured = properties.getInstances();
+        if (configured == null || configured.isEmpty()) {
+            configured = new ArrayList<>();
+            SandboxProperties.Instance fallback = new SandboxProperties.Instance();
+            fallback.setId("default");
+            fallback.setWorkerUrl(properties.getWorkerUrl());
+            fallback.setWorkerMcpUrl(properties.getWorkerMcpUrl());
+            fallback.setWorkerStreamUrl(properties.getWorkerStreamUrl());
+            fallback.setWorkerOpsUrl(properties.getWorkerOpsUrl());
+            fallback.setWorkerVncUrl(properties.getWorkerVncUrl());
+            fallback.setMaxSessions(1);
+            configured.add(fallback);
+        }
+        for (SandboxProperties.Instance instance : configured) {
+            SandboxRuntime runtime = SandboxRuntime.from(instance, properties);
+            sandboxes.put(runtime.id, runtime);
+        }
+        log.info("沙箱池初始化完成: sandboxCount={}", sandboxes.size());
+    }
+
+    private static class SandboxRuntime {
+        private String id;
+        private String workerUrl;
+        private String workerMcpUrl;
+        private String workerStreamUrl;
+        private String workerOpsUrl;
+        private String workerVncUrl;
+        private int maxSessions;
+        private final List<String> agentIds = new ArrayList<>();
+
+        private static SandboxRuntime from(SandboxProperties.Instance instance, SandboxProperties defaults) {
+            SandboxRuntime runtime = new SandboxRuntime();
+            runtime.id = StringUtils.defaultIfBlank(instance.getId(), instance.getWorkerUrl());
+            runtime.workerUrl = StringUtils.defaultIfBlank(instance.getWorkerUrl(), defaults.getWorkerUrl());
+            runtime.workerMcpUrl = StringUtils.defaultIfBlank(instance.getWorkerMcpUrl(), defaults.getWorkerMcpUrl());
+            runtime.workerStreamUrl = StringUtils.defaultIfBlank(instance.getWorkerStreamUrl(), defaults.getWorkerStreamUrl());
+            runtime.workerOpsUrl = StringUtils.defaultIfBlank(instance.getWorkerOpsUrl(), defaults.getWorkerOpsUrl());
+            runtime.workerVncUrl = StringUtils.defaultIfBlank(instance.getWorkerVncUrl(), defaults.getWorkerVncUrl());
+            runtime.maxSessions = instance.getMaxSessions() == null || instance.getMaxSessions() < 1 ? 1 : instance.getMaxSessions();
+            return runtime;
+        }
+    }
+}

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxProperties.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxProperties.java
@@ -1,0 +1,33 @@
+package cn.nolaurene.cms.service.sandbox.backend.sandbox;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "sandbox.backend")
+public class SandboxProperties {
+
+    private String workerUrl;
+    private String workerMcpUrl;
+    private String workerStreamUrl;
+    private String workerOpsUrl;
+    private String workerVncUrl;
+    private String sseEndpoint;
+    private List<Instance> instances = new ArrayList<>();
+
+    @Data
+    public static class Instance {
+        private String id;
+        private String workerUrl;
+        private String workerMcpUrl;
+        private String workerStreamUrl;
+        private String workerOpsUrl;
+        private String workerVncUrl;
+        private Integer maxSessions = 1;
+    }
+}

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxUrlResolver.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/sandbox/SandboxUrlResolver.java
@@ -1,0 +1,41 @@
+package cn.nolaurene.cms.service.sandbox.backend.sandbox;
+
+import cn.nolaurene.cms.service.sandbox.backend.agent.AgentSession;
+import cn.nolaurene.cms.service.sandbox.backend.session.GlobalAgentSessionManager;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SandboxUrlResolver {
+
+    private final GlobalAgentSessionManager sessionManager;
+    private final SandboxProperties properties;
+
+    public SandboxUrlResolver(GlobalAgentSessionManager sessionManager, SandboxProperties properties) {
+        this.sessionManager = sessionManager;
+        this.properties = properties;
+    }
+
+    public String workerStreamUrl(String agentId) {
+        SandboxLease lease = findLease(agentId);
+        return StringUtils.defaultIfBlank(lease == null ? null : lease.getWorkerStreamUrl(), properties.getWorkerStreamUrl());
+    }
+
+    public String workerOpsUrl(String agentId) {
+        SandboxLease lease = findLease(agentId);
+        return StringUtils.defaultIfBlank(lease == null ? null : lease.getWorkerOpsUrl(), properties.getWorkerOpsUrl());
+    }
+
+    public String workerVncUrl(String agentId) {
+        SandboxLease lease = findLease(agentId);
+        return StringUtils.defaultIfBlank(lease == null ? null : lease.getWorkerVncUrl(), properties.getWorkerVncUrl());
+    }
+
+    private SandboxLease findLease(String agentId) {
+        if (StringUtils.isBlank(agentId)) {
+            return null;
+        }
+        AgentSession session = sessionManager.getSession(agentId);
+        return session == null ? null : session.getSandboxLease();
+    }
+}

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/session/GlobalAgentSessionManager.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/session/GlobalAgentSessionManager.java
@@ -4,6 +4,7 @@ import cn.nolaurene.cms.service.sandbox.backend.agent.AgentSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,22 +19,15 @@ public class GlobalAgentSessionManager {
     private final ConcurrentHashMap<String, AgentSession> localSessions = new ConcurrentHashMap<>();
 
     public boolean createSession(String agentId, AgentSession session) {
-        if (localSessions.containsKey(agentId)) {
-            // 如果会话已存在，返回已有的agent
-            return false;
-        }
         // 将新创建的agent存入本地会话
-        localSessions.put(agentId, session);
-
-        return true;
+        return localSessions.putIfAbsent(agentId, session) == null;
     }
 
     public boolean removeSession(String agentId) {
-        if (!localSessions.containsKey(agentId)) {
-            return true;
+        AgentSession removed = localSessions.remove(agentId);
+        if (removed != null) {
+            removed.releaseResources();
         }
-
-        localSessions.remove(agentId);
         return true; // 成功删除会话
     }
 
@@ -43,6 +37,11 @@ public class GlobalAgentSessionManager {
 
     public List<String> getAllSessionIds() {
         return new ArrayList<>(localSessions.keySet());
+    }
+
+    @PreDestroy
+    public void releaseAllSessions() {
+        new ArrayList<>(localSessions.keySet()).forEach(this::removeSession);
     }
 
     // TODO：分布式情况下存储session

--- a/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/vnc/VncWebSocketHandler.java
+++ b/backend/src/main/java/cn/nolaurene/cms/service/sandbox/backend/vnc/VncWebSocketHandler.java
@@ -1,12 +1,10 @@
 package cn.nolaurene.cms.service.sandbox.backend.vnc;
 
+import cn.nolaurene.cms.service.sandbox.backend.sandbox.SandboxUrlResolver;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.*;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
-import org.springframework.web.util.UriComponentsBuilder;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
@@ -21,8 +19,11 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class VncWebSocketHandler implements WebSocketHandler {
 
-    @Value("${sandbox.backend.worker-vnc-url:ws://worker:5902}")
-    private String workerVncUrl;
+    private final SandboxUrlResolver sandboxUrlResolver;
+
+    public VncWebSocketHandler(SandboxUrlResolver sandboxUrlResolver) {
+        this.sandboxUrlResolver = sandboxUrlResolver;
+    }
 
     // 存储前端连接与 worker 连接的映射
     private final Map<String, WebSocketSession> frontendSessions = new ConcurrentHashMap<>();
@@ -102,7 +103,7 @@ public class VncWebSocketHandler implements WebSocketHandler {
             client.setUserProperties(Map.of(
                 "org.apache.tomcat.websocket.IO_TIMEOUT_MS", "300000"
             ));
-            client.doHandshake(workerHandler, workerVncUrl).get(10, TimeUnit.SECONDS);
+            client.doHandshake(workerHandler, sandboxUrlResolver.workerVncUrl(customSessionId)).get(10, TimeUnit.SECONDS);
             frontendSessions.put(sessionId, frontendSession);
             
             log.info("VNC 代理连接建立成功: sessionId={}", logSessionId);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -60,6 +60,15 @@ sandbox:
     worker-ops-url: http://worker:7002
     worker-vnc-url: ws://worker:5902
     sse-endpoint: /sse
+    # 沙箱池配置；未配置 instances 时会自动使用上面的 worker-* 作为 default 沙箱。
+    instances:
+      - id: default
+        worker-url: http://worker:7500
+        worker-mcp-url: http://worker:7002
+        worker-stream-url: http://worker:7002
+        worker-ops-url: http://worker:7002
+        worker-vnc-url: ws://worker:5902
+        max-sessions: 1
   worker:
     #    baseDirectory: /app
     playwright-mcp-version: 0.0.39

--- a/frontend/src/services/api/sandbox.ts
+++ b/frontend/src/services/api/sandbox.ts
@@ -120,6 +120,16 @@ export async function createAgent(): Promise<Agent> {
   return response.data;
 }
 
+export async function releaseAgent(agentId: string): Promise<boolean> {
+  const response = await request<API.Response<boolean>>(`/agents/${agentId}`, {method: 'DELETE'});
+  if (!response || !response.success) {
+    console.error("Failed to release agent");
+    return Promise.reject(response?.message || "Failed to release agent");
+  }
+  // @ts-ignore
+  return response.data;
+}
+
 export const getVNCUrl = (agentId: string): string => {
   // Convert http to ws, https to wss
   const wsBaseUrl = "wss://localhost:8000";


### PR DESCRIPTION
### Motivation
- Provide an alloc/release mechanism so each agent gets a sandbox/worker lease and resources can be returned when the session ends.
- Prevent resource leaks by ensuring MCP clients are unregistered from heartbeat and closed when a session is removed or initialization fails.
- Route stream/shell/VNC traffic to the worker instance tied to an agent's lease so multi-instance deployments are supported.

### Description
- Add a configurable sandbox pool with `SandboxPoolService`, `SandboxLease`, and `SandboxProperties` to acquire/release leases and enumerate configured instances, and a `SandboxUrlResolver` to resolve per-agent worker URLs via the lease.
- Change agent creation to `acquire` a sandbox lease before initializing `AgentSession` and add a `DELETE /agents/{agentId}` endpoint to release the session and its resources, and make `AgentSessionFactory` accept a `SandboxLease` when creating sessions.
- Update `AgentSession` to initialize browser/native MCP clients from the `SandboxLease`, register/unregister clients with `McpHeartbeatService`, and implement `releaseResources()` to close MCP clients and call `SandboxPoolService.release`.
- Wire proxy/controllers and websocket handlers (`BrowserStreamProxyController`, `ShellManageController`, `VncProxyController`, `BackendShellWebSocketHandler`, VNC handler) to use `SandboxUrlResolver` so streaming/shell/VNC requests go to the correct worker instance.

### Testing
- Ran code checks: `git diff --check` on the modified files completed with no whitespace errors.
- Attempted backend compile with `./mvnw -q -DskipTests compile` but it failed due to `mvnw` not being executable in this workspace (permission denied).
- Attempted `mvn -q -DskipTests compile` and `mvn -o -q -DskipTests compile` but both builds could not resolve the Spring Boot parent POM (`org.springframework.boot:spring-boot-starter-parent:2.7.17`) due to network/cache restrictions, so no integration or unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2173c0ab7483298400d3a2a706eceb)